### PR TITLE
Use a struct packet instead of an array

### DIFF
--- a/Adafruit_Fingerprint.cpp
+++ b/Adafruit_Fingerprint.cpp
@@ -1,16 +1,16 @@
-/*************************************************** 
+/***************************************************
   This is a library for our optical Fingerprint sensor
 
-  Designed specifically to work with the Adafruit Fingerprint sensor 
+  Designed specifically to work with the Adafruit Fingerprint sensor
   ----> http://www.adafruit.com/products/751
 
-  These displays use TTL Serial to communicate, 2 pins are required to 
+  These displays use TTL Serial to communicate, 2 pins are required to
   interface
-  Adafruit invests time and resources providing this open source code, 
-  please support Adafruit and open-source hardware by purchasing 
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
   products from Adafruit!
 
-  Written by Limor Fried/Ladyada for Adafruit Industries.  
+  Written by Limor Fried/Ladyada for Adafruit Industries.
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
@@ -52,12 +52,12 @@ void Adafruit_Fingerprint::begin(uint16_t baudrate) {
 }
 
 boolean Adafruit_Fingerprint::verifyPassword(void) {
-  uint8_t packet[] = {FINGERPRINT_VERIFYPASSWORD, 
+  uint8_t packet[] = {FINGERPRINT_VERIFYPASSWORD,
                       (thePassword >> 24), (thePassword >> 16),
                       (thePassword >> 8), thePassword};
   writePacket(theAddress, FINGERPRINT_COMMANDPACKET, 7, packet);
   uint8_t len = getReply(packet);
-  
+
   if ((len == 1) && (packet[0] == FINGERPRINT_ACKPACKET) && (packet[1] == FINGERPRINT_OK))
     return true;
 
@@ -75,7 +75,7 @@ uint8_t Adafruit_Fingerprint::getImage(void) {
   uint8_t packet[] = {FINGERPRINT_GETIMAGE};
   writePacket(theAddress, FINGERPRINT_COMMANDPACKET, 3, packet);
   uint8_t len = getReply(packet);
-  
+
   if ((len != 1) && (packet[0] != FINGERPRINT_ACKPACKET))
    return -1;
   return packet[1];
@@ -85,7 +85,7 @@ uint8_t Adafruit_Fingerprint::image2Tz(uint8_t slot) {
   uint8_t packet[] = {FINGERPRINT_IMAGE2TZ, slot};
   writePacket(theAddress, FINGERPRINT_COMMANDPACKET, sizeof(packet)+2, packet);
   uint8_t len = getReply(packet);
-  
+
   if ((len != 1) && (packet[0] != FINGERPRINT_ACKPACKET))
    return -1;
   return packet[1];
@@ -96,7 +96,7 @@ uint8_t Adafruit_Fingerprint::createModel(void) {
   uint8_t packet[] = {FINGERPRINT_REGMODEL};
   writePacket(theAddress, FINGERPRINT_COMMANDPACKET, sizeof(packet)+2, packet);
   uint8_t len = getReply(packet);
-  
+
   if ((len != 1) && (packet[0] != FINGERPRINT_ACKPACKET))
    return -1;
   return packet[1];
@@ -107,18 +107,18 @@ uint8_t Adafruit_Fingerprint::storeModel(uint16_t id) {
   uint8_t packet[] = {FINGERPRINT_STORE, 0x01, id >> 8, id & 0xFF};
   writePacket(theAddress, FINGERPRINT_COMMANDPACKET, sizeof(packet)+2, packet);
   uint8_t len = getReply(packet);
-  
+
   if ((len != 1) && (packet[0] != FINGERPRINT_ACKPACKET))
    return -1;
   return packet[1];
 }
-    
+
 //read a fingerprint template from flash into Char Buffer 1
 uint8_t Adafruit_Fingerprint::loadModel(uint16_t id) {
     uint8_t packet[] = {FINGERPRINT_LOAD, 0x01, id >> 8, id & 0xFF};
     writePacket(theAddress, FINGERPRINT_COMMANDPACKET, sizeof(packet)+2, packet);
     uint8_t len = getReply(packet);
-    
+
     if ((len != 1) && (packet[0] != FINGERPRINT_ACKPACKET))
         return -1;
     return packet[1];
@@ -129,17 +129,17 @@ uint8_t Adafruit_Fingerprint::getModel(void) {
     uint8_t packet[] = {FINGERPRINT_UPLOAD, 0x01};
     writePacket(theAddress, FINGERPRINT_COMMANDPACKET, sizeof(packet)+2, packet);
     uint8_t len = getReply(packet);
-    
+
     if ((len != 1) && (packet[0] != FINGERPRINT_ACKPACKET))
         return -1;
     return packet[1];
 }
-    
+
 uint8_t Adafruit_Fingerprint::deleteModel(uint16_t id) {
     uint8_t packet[] = {FINGERPRINT_DELETE, id >> 8, id & 0xFF, 0x00, 0x01};
     writePacket(theAddress, FINGERPRINT_COMMANDPACKET, sizeof(packet)+2, packet);
     uint8_t len = getReply(packet);
-        
+
     if ((len != 1) && (packet[0] != FINGERPRINT_ACKPACKET))
         return -1;
     return packet[1];
@@ -149,7 +149,7 @@ uint8_t Adafruit_Fingerprint::emptyDatabase(void) {
   uint8_t packet[] = {FINGERPRINT_EMPTY};
   writePacket(theAddress, FINGERPRINT_COMMANDPACKET, sizeof(packet)+2, packet);
   uint8_t len = getReply(packet);
-  
+
   if ((len != 1) && (packet[0] != FINGERPRINT_ACKPACKET))
    return -1;
   return packet[1];
@@ -158,22 +158,22 @@ uint8_t Adafruit_Fingerprint::emptyDatabase(void) {
 uint8_t Adafruit_Fingerprint::fingerFastSearch(void) {
   fingerID = 0xFFFF;
   confidence = 0xFFFF;
-  // high speed search of slot #1 starting at page 0x0000 and page #0x00A3 
+  // high speed search of slot #1 starting at page 0x0000 and page #0x00A3
   uint8_t packet[] = {FINGERPRINT_HISPEEDSEARCH, 0x01, 0x00, 0x00, 0x00, 0xA3};
   writePacket(theAddress, FINGERPRINT_COMMANDPACKET, sizeof(packet)+2, packet);
   uint8_t len = getReply(packet);
-  
+
   if ((len != 1) && (packet[0] != FINGERPRINT_ACKPACKET))
    return -1;
 
   fingerID = packet[2];
   fingerID <<= 8;
   fingerID |= packet[3];
-  
+
   confidence = packet[4];
   confidence <<= 8;
   confidence |= packet[5];
-  
+
   return packet[1];
 }
 
@@ -183,20 +183,20 @@ uint8_t Adafruit_Fingerprint::getTemplateCount(void) {
   uint8_t packet[] = {FINGERPRINT_TEMPLATECOUNT};
   writePacket(theAddress, FINGERPRINT_COMMANDPACKET, sizeof(packet)+2, packet);
   uint8_t len = getReply(packet);
-  
+
   if ((len != 1) && (packet[0] != FINGERPRINT_ACKPACKET))
    return -1;
 
   templateCount = packet[2];
   templateCount <<= 8;
   templateCount |= packet[3];
-  
+
   return packet[1];
 }
 
 
 
-void Adafruit_Fingerprint::writePacket(uint32_t addr, uint8_t packettype, 
+void Adafruit_Fingerprint::writePacket(uint32_t addr, uint8_t packettype,
 				       uint16_t len, uint8_t *packet) {
 #ifdef FINGERPRINT_DEBUG
   Serial.print("---> 0x");
@@ -218,7 +218,7 @@ void Adafruit_Fingerprint::writePacket(uint32_t addr, uint8_t packettype,
   Serial.print(" 0x");
   Serial.print((uint8_t)(len), HEX);
 #endif
- 
+
 #if ARDUINO >= 100
   mySerial->write((uint8_t)(FINGERPRINT_STARTCODE >> 8));
   mySerial->write((uint8_t)FINGERPRINT_STARTCODE);
@@ -240,7 +240,7 @@ void Adafruit_Fingerprint::writePacket(uint32_t addr, uint8_t packettype,
   mySerial->print((uint8_t)(len >> 8), BYTE);
   mySerial->print((uint8_t)(len), BYTE);
 #endif
-  
+
   uint16_t sum = (len>>8) + (len&0xFF) + packettype;
   for (uint8_t i=0; i< len-2; i++) {
 #if ARDUINO >= 100
@@ -271,7 +271,7 @@ void Adafruit_Fingerprint::writePacket(uint32_t addr, uint8_t packettype,
 uint8_t Adafruit_Fingerprint::getReply(uint8_t packet[], uint16_t timeout) {
   uint8_t reply[20], idx;
   uint16_t timer=0;
-  
+
   idx = 0;
 #ifdef FINGERPRINT_DEBUG
   Serial.print("<--- ");
@@ -290,7 +290,7 @@ while (true) {
     if ((idx == 0) && (reply[0] != (FINGERPRINT_STARTCODE >> 8)))
       continue;
     idx++;
-    
+
     // check packet!
     if (idx >= 9) {
       if ((reply[0] != (FINGERPRINT_STARTCODE >> 8)) ||
@@ -304,7 +304,7 @@ while (true) {
       len -= 2;
       //Serial.print("Packet len"); Serial.println(len);
       if (idx <= (len+10)) continue;
-      packet[0] = packettype;      
+      packet[0] = packettype;
       for (uint8_t i=0; i<len; i++) {
         packet[1+i] = reply[9+i];
       }

--- a/Adafruit_Fingerprint.h
+++ b/Adafruit_Fingerprint.h
@@ -71,6 +71,20 @@
 
 #define DEFAULTTIMEOUT 5000  // milliseconds
 
+struct Adafruit_Fingerprint_Packet {
+  Adafruit_Fingerprint_Packet(uint8_t type, uint16_t length, uint8_t * data) : start_code(FINGERPRINT_STARTCODE), type(type), length(length) {
+    memset(address, 0xFF, 4);
+    if(length<64)
+      memcpy(this->data, data, length);
+    else
+      memcpy(this->data, data, 64);
+  }
+  uint16_t start_code;
+  uint8_t address[4];
+  uint8_t type;
+  uint16_t length;
+  uint8_t data[64];
+};
 
 class Adafruit_Fingerprint {
  public:
@@ -93,6 +107,8 @@ class Adafruit_Fingerprint {
   uint8_t deleteModel(uint16_t id);
   uint8_t fingerFastSearch(void);
   uint8_t getTemplateCount(void);
+  uint8_t writeStructuredPacket(const Adafruit_Fingerprint_Packet & p);
+  uint8_t getStructuredPacket(Adafruit_Fingerprint_Packet * p, uint16_t timeout=DEFAULTTIMEOUT);
   void writePacket(uint32_t addr, uint8_t packettype, uint16_t len, uint8_t *packet);
   uint8_t getReply(uint8_t packet[], uint16_t timeout=DEFAULTTIMEOUT);
 

--- a/Adafruit_Fingerprint.h
+++ b/Adafruit_Fingerprint.h
@@ -1,3 +1,6 @@
+#ifndef ADAFRUIT_FINGERPRINT_H
+#define ADAFRUIT_FINGERPRINT_H
+
 /***************************************************
   This is a library for our optical Fingerprint sensor
 
@@ -105,3 +108,5 @@ class Adafruit_Fingerprint {
 #endif
   HardwareSerial *hwSerial;
 };
+
+#endif

--- a/Adafruit_Fingerprint.h
+++ b/Adafruit_Fingerprint.h
@@ -1,16 +1,16 @@
-/*************************************************** 
+/***************************************************
   This is a library for our optical Fingerprint sensor
 
   Designed specifically to work with the Adafruit Fingerprint sensor
   ----> http://www.adafruit.com/products/751
 
-  These displays use TTL Serial to communicate, 2 pins are required to 
+  These displays use TTL Serial to communicate, 2 pins are required to
   interface
-  Adafruit invests time and resources providing this open source code, 
-  please support Adafruit and open-source hardware by purchasing 
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
   products from Adafruit!
 
-  Written by Limor Fried/Ladyada for Adafruit Industries.  
+  Written by Limor Fried/Ladyada for Adafruit Industries.
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
@@ -64,7 +64,7 @@
 #define FINGERPRINT_HISPEEDSEARCH 0x1B
 #define FINGERPRINT_TEMPLATECOUNT 0x1D
 
-//#define FINGERPRINT_DEBUG 
+//#define FINGERPRINT_DEBUG
 
 #define DEFAULTTIMEOUT 5000  // milliseconds
 
@@ -95,7 +95,7 @@ class Adafruit_Fingerprint {
 
   uint16_t fingerID, confidence, templateCount;
 
- private: 
+ private:
   uint32_t thePassword;
   uint32_t theAddress;
 

--- a/Adafruit_Fingerprint.h
+++ b/Adafruit_Fingerprint.h
@@ -72,8 +72,12 @@
 #define DEFAULTTIMEOUT 5000  // milliseconds
 
 struct Adafruit_Fingerprint_Packet {
-  Adafruit_Fingerprint_Packet(uint8_t type, uint16_t length, uint8_t * data) : start_code(FINGERPRINT_STARTCODE), type(type), length(length) {
-    memset(address, 0xFF, 4);
+  Adafruit_Fingerprint_Packet(uint8_t type, uint16_t length, uint8_t * data) {
+    this->start_code = FINGERPRINT_STARTCODE;
+    this->type = type;
+    this->length = length;
+    address[0] = 0xFF; address[1] = 0xFF;
+    address[2] = 0xFF; address[3] = 0xFF;
     if(length<64)
       memcpy(this->data, data, length);
     else
@@ -107,10 +111,8 @@ class Adafruit_Fingerprint {
   uint8_t deleteModel(uint16_t id);
   uint8_t fingerFastSearch(void);
   uint8_t getTemplateCount(void);
-  uint8_t writeStructuredPacket(const Adafruit_Fingerprint_Packet & p);
+  void writeStructuredPacket(const Adafruit_Fingerprint_Packet & p);
   uint8_t getStructuredPacket(Adafruit_Fingerprint_Packet * p, uint16_t timeout=DEFAULTTIMEOUT);
-  void writePacket(uint32_t addr, uint8_t packettype, uint16_t len, uint8_t *packet);
-  uint8_t getReply(uint8_t packet[], uint16_t timeout=DEFAULTTIMEOUT);
 
   uint16_t fingerID, confidence, templateCount;
 


### PR DESCRIPTION
There are flaws in the library's handling of packet transmission and reception that result in buffer overflows and memory corruption. I'm fairly certain these are specifically due to the use of short uint8_t arrays to send and receive packets; where the arrays are based on the sent packet payload without regard to the length of the respond payload. There are even compiler warnings about this.

My fix is to utilize a single struct that encompasses all the fields of the packet, and names them. I'm currently using a fixed body of 64 bytes, which may be excessive; but I don't know the protocol well enough to know what the largest actual packet size would be.

This works for my use case, seems reliable, and does not exhibit the system-breaking behavior of the existing library's overflows.
- **Scope**: All command functions.
- **Limitations**: None known.
- **Examples**: I'm using the main functionality of the device in my own code but I haven't tested with the examples. I'll try this out tomorrow.
