### PR TITLE
anay: Fixing an issue with createModel where the packet was not being…

### DIFF
--- a/Adafruit_Fingerprint.cpp
+++ b/Adafruit_Fingerprint.cpp
@@ -1,16 +1,16 @@
-/*************************************************** 
+/***************************************************
   This is a library for our optical Fingerprint sensor
 
-  Designed specifically to work with the Adafruit Fingerprint sensor 
+  Designed specifically to work with the Adafruit Fingerprint sensor
   ----> http://www.adafruit.com/products/751
 
-  These displays use TTL Serial to communicate, 2 pins are required to 
+  These displays use TTL Serial to communicate, 2 pins are required to
   interface
-  Adafruit invests time and resources providing this open source code, 
-  please support Adafruit and open-source hardware by purchasing 
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
   products from Adafruit!
 
-  Written by Limor Fried/Ladyada for Adafruit Industries.  
+  Written by Limor Fried/Ladyada for Adafruit Industries.
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
@@ -52,12 +52,15 @@ void Adafruit_Fingerprint::begin(uint16_t baudrate) {
 }
 
 boolean Adafruit_Fingerprint::verifyPassword(void) {
-  uint8_t packet[] = {FINGERPRINT_VERIFYPASSWORD, 
-                      (thePassword >> 24), (thePassword >> 16),
-                      (thePassword >> 8), thePassword};
+  packet[0] = FINGERPRINT_VERIFYPASSWORD;
+  packet[1] = (thePassword >> 24);
+  packet[2] = (thePassword >> 16);
+  packet[3] = (thePassword >> 8);
+  packet[4] = thePassword;
+
   writePacket(theAddress, FINGERPRINT_COMMANDPACKET, 7, packet);
   uint8_t len = getReply(packet);
-  
+
   if ((len == 1) && (packet[0] == FINGERPRINT_ACKPACKET) && (packet[1] == FINGERPRINT_OK))
     return true;
 
@@ -72,20 +75,21 @@ boolean Adafruit_Fingerprint::verifyPassword(void) {
 }
 
 uint8_t Adafruit_Fingerprint::getImage(void) {
-  uint8_t packet[] = {FINGERPRINT_GETIMAGE};
+  packet[0] = FINGERPRINT_GETIMAGE;
   writePacket(theAddress, FINGERPRINT_COMMANDPACKET, 3, packet);
   uint8_t len = getReply(packet);
-  
+
   if ((len != 1) && (packet[0] != FINGERPRINT_ACKPACKET))
    return -1;
   return packet[1];
 }
 
 uint8_t Adafruit_Fingerprint::image2Tz(uint8_t slot) {
-  uint8_t packet[] = {FINGERPRINT_IMAGE2TZ, slot};
-  writePacket(theAddress, FINGERPRINT_COMMANDPACKET, sizeof(packet)+2, packet);
+  packet[0] = FINGERPRINT_IMAGE2TZ;
+  packet[1] = slot;
+  writePacket(theAddress, FINGERPRINT_COMMANDPACKET, 4, packet);
   uint8_t len = getReply(packet);
-  
+
   if ((len != 1) && (packet[0] != FINGERPRINT_ACKPACKET))
    return -1;
   return packet[1];
@@ -93,10 +97,10 @@ uint8_t Adafruit_Fingerprint::image2Tz(uint8_t slot) {
 
 
 uint8_t Adafruit_Fingerprint::createModel(void) {
-  uint8_t packet[] = {FINGERPRINT_REGMODEL};
-  writePacket(theAddress, FINGERPRINT_COMMANDPACKET, sizeof(packet)+2, packet);
+  packet[0] = FINGERPRINT_REGMODEL;
+  writePacket(theAddress, FINGERPRINT_COMMANDPACKET, 3, packet);
   uint8_t len = getReply(packet);
-  
+
   if ((len != 1) && (packet[0] != FINGERPRINT_ACKPACKET))
    return -1;
   return packet[1];
@@ -104,21 +108,27 @@ uint8_t Adafruit_Fingerprint::createModel(void) {
 
 
 uint8_t Adafruit_Fingerprint::storeModel(uint16_t id) {
-  uint8_t packet[] = {FINGERPRINT_STORE, 0x01, id >> 8, id & 0xFF};
-  writePacket(theAddress, FINGERPRINT_COMMANDPACKET, sizeof(packet)+2, packet);
+  packet[0] = FINGERPRINT_STORE;
+  packet[1] = 0x01;
+  packet[2] = id >> 8;
+  packet[3] = id & 0xFF;
+  writePacket(theAddress, FINGERPRINT_COMMANDPACKET, 6, packet);
   uint8_t len = getReply(packet);
-  
+
   if ((len != 1) && (packet[0] != FINGERPRINT_ACKPACKET))
    return -1;
   return packet[1];
 }
-    
+
 //read a fingerprint template from flash into Char Buffer 1
 uint8_t Adafruit_Fingerprint::loadModel(uint16_t id) {
-    uint8_t packet[] = {FINGERPRINT_LOAD, 0x01, id >> 8, id & 0xFF};
-    writePacket(theAddress, FINGERPRINT_COMMANDPACKET, sizeof(packet)+2, packet);
+    packet[0] = FINGERPRINT_LOAD;
+    packet[1] = 0x01;
+    packet[2] = id >> 8;
+    packet[3] = id & 0xFF;
+    writePacket(theAddress, FINGERPRINT_COMMANDPACKET, 6, packet);
     uint8_t len = getReply(packet);
-    
+
     if ((len != 1) && (packet[0] != FINGERPRINT_ACKPACKET))
         return -1;
     return packet[1];
@@ -126,30 +136,35 @@ uint8_t Adafruit_Fingerprint::loadModel(uint16_t id) {
 
 //transfer a fingerprint template from Char Buffer 1 to host computer
 uint8_t Adafruit_Fingerprint::getModel(void) {
-    uint8_t packet[] = {FINGERPRINT_UPLOAD, 0x01};
-    writePacket(theAddress, FINGERPRINT_COMMANDPACKET, sizeof(packet)+2, packet);
+    packet[0] = FINGERPRINT_UPLOAD;
+    packet[1] = 0x01;
+    writePacket(theAddress, FINGERPRINT_COMMANDPACKET, 4, packet);
     uint8_t len = getReply(packet);
-    
+
     if ((len != 1) && (packet[0] != FINGERPRINT_ACKPACKET))
         return -1;
     return packet[1];
 }
-    
+
 uint8_t Adafruit_Fingerprint::deleteModel(uint16_t id) {
-    uint8_t packet[] = {FINGERPRINT_DELETE, id >> 8, id & 0xFF, 0x00, 0x01};
-    writePacket(theAddress, FINGERPRINT_COMMANDPACKET, sizeof(packet)+2, packet);
+    packet[0] = FINGERPRINT_DELETE;
+    packet[1] = id >> 8;
+    packet[2] = id & 0xFF;
+    packet[3] = 0x00;
+    packet[4] = 0x01;
+    writePacket(theAddress, FINGERPRINT_COMMANDPACKET, 7, packet);
     uint8_t len = getReply(packet);
-        
+
     if ((len != 1) && (packet[0] != FINGERPRINT_ACKPACKET))
         return -1;
     return packet[1];
 }
 
 uint8_t Adafruit_Fingerprint::emptyDatabase(void) {
-  uint8_t packet[] = {FINGERPRINT_EMPTY};
-  writePacket(theAddress, FINGERPRINT_COMMANDPACKET, sizeof(packet)+2, packet);
+  packet[0] = FINGERPRINT_EMPTY;
+  writePacket(theAddress, FINGERPRINT_COMMANDPACKET, 3, packet);
   uint8_t len = getReply(packet);
-  
+
   if ((len != 1) && (packet[0] != FINGERPRINT_ACKPACKET))
    return -1;
   return packet[1];
@@ -158,45 +173,50 @@ uint8_t Adafruit_Fingerprint::emptyDatabase(void) {
 uint8_t Adafruit_Fingerprint::fingerFastSearch(void) {
   fingerID = 0xFFFF;
   confidence = 0xFFFF;
-  // high speed search of slot #1 starting at page 0x0000 and page #0x00A3 
-  uint8_t packet[] = {FINGERPRINT_HISPEEDSEARCH, 0x01, 0x00, 0x00, 0x00, 0xA3};
-  writePacket(theAddress, FINGERPRINT_COMMANDPACKET, sizeof(packet)+2, packet);
+  // high speed search of slot #1 starting at page 0x0000 and page #0x00A3
+  packet[0] = FINGERPRINT_HISPEEDSEARCH;
+  packet[1] = 0x01;
+  packet[2] = 0x00;
+  packet[3] = 0x00;
+  packet[4] = 0x00;
+  packet[5] = 0xA3;
+  writePacket(theAddress, FINGERPRINT_COMMANDPACKET, 8, packet);
   uint8_t len = getReply(packet);
-  
+
   if ((len != 1) && (packet[0] != FINGERPRINT_ACKPACKET))
    return -1;
 
   fingerID = packet[2];
   fingerID <<= 8;
   fingerID |= packet[3];
-  
+
   confidence = packet[4];
   confidence <<= 8;
   confidence |= packet[5];
-  
+
   return packet[1];
 }
 
 uint8_t Adafruit_Fingerprint::getTemplateCount(void) {
   templateCount = 0xFFFF;
   // get number of templates in memory
-  uint8_t packet[] = {FINGERPRINT_TEMPLATECOUNT};
-  writePacket(theAddress, FINGERPRINT_COMMANDPACKET, sizeof(packet)+2, packet);
+  packet[0] = FINGERPRINT_TEMPLATECOUNT;
+  writePacket(theAddress, FINGERPRINT_COMMANDPACKET, 3, packet);
   uint8_t len = getReply(packet);
-  
+
   if ((len != 1) && (packet[0] != FINGERPRINT_ACKPACKET))
    return -1;
 
   templateCount = packet[2];
   templateCount <<= 8;
   templateCount |= packet[3];
-  
+
   return packet[1];
 }
 
 
 
-void Adafruit_Fingerprint::writePacket(uint32_t addr, uint8_t packettype, 
+void Adafruit_Fingerprint::writePacket(uint32_t addr, uint8_t packettype,
 				       uint16_t len, uint8_t *packet) {
 #ifdef FINGERPRINT_DEBUG
   Serial.print("---> 0x");
@@ -218,7 +238,7 @@ void Adafruit_Fingerprint::writePacket(uint32_t addr, uint8_t packettype,
   Serial.print(" 0x");
   Serial.print((uint8_t)(len), HEX);
 #endif
- 
+
 #if ARDUINO >= 100
   mySerial->write((uint8_t)(FINGERPRINT_STARTCODE >> 8));
   mySerial->write((uint8_t)FINGERPRINT_STARTCODE);
@@ -240,7 +260,7 @@ void Adafruit_Fingerprint::writePacket(uint32_t addr, uint8_t packettype,
   mySerial->print((uint8_t)(len >> 8), BYTE);
   mySerial->print((uint8_t)(len), BYTE);
 #endif
-  
+
   uint16_t sum = (len>>8) + (len&0xFF) + packettype;
   for (uint8_t i=0; i< len-2; i++) {
 #if ARDUINO >= 100
@@ -271,7 +291,7 @@ void Adafruit_Fingerprint::writePacket(uint32_t addr, uint8_t packettype,
 uint8_t Adafruit_Fingerprint::getReply(uint8_t packet[], uint16_t timeout) {
   uint8_t reply[20], idx;
   uint16_t timer=0;
-  
+
   idx = 0;
 #ifdef FINGERPRINT_DEBUG
   Serial.print("<--- ");
@@ -290,7 +310,7 @@ while (true) {
     if ((idx == 0) && (reply[0] != (FINGERPRINT_STARTCODE >> 8)))
       continue;
     idx++;
-    
+
     // check packet!
     if (idx >= 9) {
       if ((reply[0] != (FINGERPRINT_STARTCODE >> 8)) ||
@@ -304,7 +324,7 @@ while (true) {
       len -= 2;
       //Serial.print("Packet len"); Serial.println(len);
       if (idx <= (len+10)) continue;
-      packet[0] = packettype;      
+      packet[0] = packettype;
       for (uint8_t i=0; i<len; i++) {
         packet[1+i] = reply[9+i];
       }
@@ -315,4 +335,3 @@ while (true) {
     }
   }
 }
-

--- a/Adafruit_Fingerprint.h
+++ b/Adafruit_Fingerprint.h
@@ -1,16 +1,16 @@
-/*************************************************** 
+/***************************************************
   This is a library for our optical Fingerprint sensor
 
   Designed specifically to work with the Adafruit Fingerprint sensor
   ----> http://www.adafruit.com/products/751
 
-  These displays use TTL Serial to communicate, 2 pins are required to 
+  These displays use TTL Serial to communicate, 2 pins are required to
   interface
-  Adafruit invests time and resources providing this open source code, 
-  please support Adafruit and open-source hardware by purchasing 
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
   products from Adafruit!
 
-  Written by Limor Fried/Ladyada for Adafruit Industries.  
+  Written by Limor Fried/Ladyada for Adafruit Industries.
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
@@ -64,7 +64,7 @@
 #define FINGERPRINT_HISPEEDSEARCH 0x1B
 #define FINGERPRINT_TEMPLATECOUNT 0x1D
 
-//#define FINGERPRINT_DEBUG 
+//#define FINGERPRINT_DEBUG
 
 #define DEFAULTTIMEOUT 5000  // milliseconds
 
@@ -95,9 +95,10 @@ class Adafruit_Fingerprint {
 
   uint16_t fingerID, confidence, templateCount;
 
- private: 
+ private:
   uint32_t thePassword;
   uint32_t theAddress;
+  uint8_t packet[10];
 
   Stream *mySerial;
 #ifdef __AVR__


### PR DESCRIPTION
Hello,

This pull request is fix for the issue which I faced where the instruction for createModel was getting modified before calling writing the packet. Due to this, we used to get the unknown error while creating the model. It was fixed by having a class level packet variable of fixed size.

While this fixes the issue, we have to hardcode the package length and cannot rely on size of packet (since this is fixed at class level). However, I noticed at few places, code already had hardcoded lengths and thus, went ahead with the change.

I have tested the code for enroll and fast search.

Considering this, kindly accept the pull request if it satisfies all the code criteria.

Thanks and regards,

Anay Kamat.
