### PR TITLE
Correcting the "unknown error" problems

### DIFF
--- a/Adafruit_Fingerprint.cpp
+++ b/Adafruit_Fingerprint.cpp
@@ -14,7 +14,7 @@
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
-#include "Fingerprint.h"
+#include "Adafruit_Fingerprint.h"
 
 #ifdef __AVR__
     #include <util/delay.h>

--- a/Adafruit_Fingerprint.h
+++ b/Adafruit_Fingerprint.h
@@ -75,7 +75,8 @@ class Adafruit_Fingerprint {
   Adafruit_Fingerprint(SoftwareSerial *);
 #endif
   Adafruit_Fingerprint(HardwareSerial *);
-
+  uint8_t packetBuffer[64];
+  
   void begin(uint16_t baud);
 
   boolean verifyPassword(void);


### PR DESCRIPTION
The scope of this change is to correct the still ongoing problems with some sketches for arduino.cc IDE 1.6.13 and the latest arduino.cc and arduino.org IDE 1.8.0.  Just adding an extra finger.getImage() statement, even if it never gets called, causes very strange array errors, even though the sketch using the library has plenty of RAM, FLASH, and EEPROM left over.  It definitely is still a compile error, and seems to have to do with the arrays that are declared and initialized within the class functions; these arrays (i.e. iuint8_t packet[], will not even allow updates and appear to have a memory access problem, perhaps on a different page.

This changes creates one 64 byte buffer as a global class variable, and has each function use a point to that instead, and it has corrected the problems.

There are no known limitations to this change, the buffer should be plenty large and the code doesn't change significantly.  It may be possible to make the buffer size smaller to accommodate sketches that are within 64 bytes of overflowing their RAM capacity; 17 bytes may only be needed, I chose 64 bytes to be more than double what would probably be needed.

All code examples will work identical for existing sketches, no modifications will be needed, only they should actually work all the time now, instead of giving an unknown error.

