### PR TITLE
High baud fix

### DIFF
--- a/Adafruit_Fingerprint.cpp
+++ b/Adafruit_Fingerprint.cpp
@@ -86,7 +86,7 @@ Adafruit_Fingerprint::Adafruit_Fingerprint(HardwareSerial *ss, uint32_t password
     @param  baudrate Sensor's UART baud rate (usually 57600, 9600 or 115200)
 */
 /**************************************************************************/
-void Adafruit_Fingerprint::begin(uint16_t baudrate) {
+void Adafruit_Fingerprint::begin(uint32_t baudrate) {
   delay(1000);  // one second delay to let the sensor 'boot up'
 
   if (hwSerial) hwSerial->begin(baudrate);

--- a/Adafruit_Fingerprint.cpp
+++ b/Adafruit_Fingerprint.cpp
@@ -15,7 +15,7 @@
  ****************************************************/
 
 #include "Adafruit_Fingerprint.h"
-#if defined(__AVR__) || defined(ESP8266)
+#if (defined(__AVR__) || defined(ESP8266)) && !defined(_DISABLE_SOFTSERIAL_)
     #include <SoftwareSerial.h>
 #endif
 
@@ -50,7 +50,7 @@
     @param  password 32-bit integer password (default is 0)
 */
 /**************************************************************************/
-#if defined(__AVR__) || defined(ESP8266)
+#if (defined(__AVR__) || defined(ESP8266)) && !defined(_DISABLE_SOFTSERIAL_)
 Adafruit_Fingerprint::Adafruit_Fingerprint(SoftwareSerial *ss, uint32_t password) {
   thePassword = password;
   theAddress = 0xFFFFFFFF;
@@ -73,7 +73,7 @@ Adafruit_Fingerprint::Adafruit_Fingerprint(HardwareSerial *ss, uint32_t password
   thePassword = password;
   theAddress = 0xFFFFFFFF;
 
-#if defined(__AVR__) || defined(ESP8266)
+#if (defined(__AVR__) || defined(ESP8266)) && !defined(_DISABLE_SOFTSERIAL_)
   swSerial = NULL;
 #endif
   hwSerial = ss;
@@ -90,7 +90,7 @@ void Adafruit_Fingerprint::begin(uint16_t baudrate) {
   delay(1000);  // one second delay to let the sensor 'boot up'
 
   if (hwSerial) hwSerial->begin(baudrate);
-#if defined(__AVR__) || defined(ESP8266)
+#if (defined(__AVR__) || defined(ESP8266)) && !defined(_DISABLE_SOFTSERIAL_)
   if (swSerial) swSerial->begin(baudrate);
 #endif
 }

--- a/Adafruit_Fingerprint.h
+++ b/Adafruit_Fingerprint.h
@@ -18,7 +18,7 @@
  ****************************************************/
 
 #include "Arduino.h"
-#if defined(__AVR__) || defined(ESP8266)
+#if (defined(__AVR__) || defined(ESP8266)) && !defined(_DISABLE_SOFTSERIAL_) // You could append "-D_DISABLE_SOFTSERIAL_" to the build command to disable SoftwareSerial for a project
   #include <SoftwareSerial.h>
 #endif
 
@@ -93,7 +93,7 @@ struct Adafruit_Fingerprint_Packet {
 
 class Adafruit_Fingerprint {
  public:
-#if defined(__AVR__) || defined(ESP8266)
+#if (defined(__AVR__) || defined(ESP8266)) && !defined(_DISABLE_SOFTSERIAL_)
   Adafruit_Fingerprint(SoftwareSerial *, uint32_t password = 0x0);
 #endif
   Adafruit_Fingerprint(HardwareSerial *, uint32_t password = 0x0);
@@ -130,7 +130,7 @@ class Adafruit_Fingerprint {
     uint8_t recvPacket[20];
 
   Stream *mySerial;
-#if defined(__AVR__) || defined(ESP8266)
+#if (defined(__AVR__) || defined(ESP8266)) && !defined(_DISABLE_SOFTSERIAL_)
   SoftwareSerial *swSerial;
 #endif
   HardwareSerial *hwSerial;

--- a/Adafruit_Fingerprint.h
+++ b/Adafruit_Fingerprint.h
@@ -98,7 +98,7 @@ class Adafruit_Fingerprint {
 #endif
   Adafruit_Fingerprint(HardwareSerial *, uint32_t password = 0x0);
 
-  void begin(uint16_t baud);
+  void begin(uint32_t baud);
 
   boolean verifyPassword(void);
   uint8_t getImage(void);


### PR DESCRIPTION
This fix makes it possible to use 115200 baud.
`begin(baud)` was asking for an unsigned short, this cannot contain 115200.

This request also includes pull #34 