### PR TITLE
Adding LED control

### DIFF
--- a/Adafruit_Fingerprint.cpp
+++ b/Adafruit_Fingerprint.cpp
@@ -144,6 +144,26 @@ uint8_t Adafruit_Fingerprint::image2Tz(uint8_t slot) {
 
 /**************************************************************************/
 /*!
+    @brief   Ask the sensor to turn on the LED
+    @returns <code>FINGERPRINT_OK</code> on success
+*/
+/**************************************************************************/
+uint8_t Adafruit_Fingerprint::ledOn(void) {
+  SEND_CMD_PACKET(FINGERPRINT_OPENLED); 
+}
+
+/**************************************************************************/
+/*!
+    @brief   Ask the sensor to turn off the LED
+    @returns <code>FINGERPRINT_OK</code> on success
+*/
+/**************************************************************************/
+uint8_t Adafruit_Fingerprint::ledOff(void) {
+  SEND_CMD_PACKET(FINGERPRINT_CLOSELED); 
+}
+
+/**************************************************************************/
+/*!
     @brief   Ask the sensor to take two print feature template and create a model
     @returns <code>FINGERPRINT_OK</code> on success
     @returns <code>FINGERPRINT_PACKETRECIEVEERR</code> on communication error

--- a/Adafruit_Fingerprint.h
+++ b/Adafruit_Fingerprint.h
@@ -67,6 +67,8 @@
 #define FINGERPRINT_VERIFYPASSWORD 0x13
 #define FINGERPRINT_HISPEEDSEARCH 0x1B
 #define FINGERPRINT_TEMPLATECOUNT 0x1D
+#define FINGERPRINT_OPENLED 0x50
+#define FINGERPRINT_CLOSELED 0x51
 
 //#define FINGERPRINT_DEBUG
 
@@ -115,6 +117,8 @@ class Adafruit_Fingerprint {
   boolean verifyPassword(void);
   uint8_t getImage(void);
   uint8_t image2Tz(uint8_t slot = 1);
+  uint8_t ledOn(void);
+  uint8_t ledOff(void);
   uint8_t createModel(void);
 
   uint8_t emptyDatabase(void);


### PR DESCRIPTION
Adding LED control functions to the library. 
The functions are called "ledOn" and "ledOff"only work on newer version of the sensor, the one with the green LED. This version doesn't have automatic LED control, and several users were having issues because the LED stayed on all the time.

I added them as stand alone functions (and not automatically called when requesting a fingerprint read) because if the user has an older version with embedded LED control, then the commands x50 and x51 won't have a meaning for the CPU.


