### PR TITLE
Add small delay after serial initialization

### DIFF
--- a/examples/fingerprint/fingerprint.ino
+++ b/examples/fingerprint/fingerprint.ino
@@ -38,7 +38,7 @@ void setup()
 
   // set the data rate for the sensor serial port
   finger.begin(57600);
-  
+  delay(5);
   if (finger.verifyPassword()) {
     Serial.println("Found fingerprint sensor!");
   } else {


### PR DESCRIPTION
I noticed that if you change a bit the setup code (by for example including a digitalWrite), they board was not able to find the fingerprint Sensor. By adding a small delay after the serial initialization, it solved the issue.
It might be related to my setup, but I waste a lot of time wondering why it was not detecting the sensor.

Board: NodeMcu Esp8266 12e
Fingerprint sensor: Not an Adafruit, Aliexpress one.
