### PR TITLE
Made option if=0 Fingerprints [Issue #76]

### DIFF
--- a/examples/fingerprint/fingerprint.ino
+++ b/examples/fingerprint/fingerprint.ino
@@ -47,8 +47,14 @@ void setup()
   }
 
   finger.getTemplateCount();
-  Serial.print("Sensor contains "); Serial.print(finger.templateCount); Serial.println(" templates");
-  Serial.println("Waiting for valid finger...");
+
+    if (finger.templateCount == 0) {
+    Serial.print("Sensor doesn't contain any fingerprint data. Please run the 'enroll' example.");
+  } 
+  else {
+    Serial.println("Waiting for valid finger...");
+      Serial.print("Sensor contains "); Serial.print(finger.templateCount); Serial.println(" templates");
+  }
 }
 
 void loop()                     // run over and over again


### PR DESCRIPTION
[Issue #76]

Minor tweak for better UX and troubleshooting. Let's you know if there is no data (Fingerprint ID's) stored. 

If **Id's = 0**, a new message is printed letting you know that there are no stored ID's.
If **Id's! = 0**, normal message (as always) is printed.