### PR TITLE
LED control

### DIFF
--- a/Adafruit_Fingerprint.cpp
+++ b/Adafruit_Fingerprint.cpp
@@ -178,6 +178,30 @@ uint8_t Adafruit_Fingerprint::image2Tz(uint8_t slot) {
   SEND_CMD_PACKET(FINGERPRINT_IMAGE2TZ, slot);
 }
 
+// Custom function
+/**************************************************************************/
+/*!
+    @brief   Ask the sensor to turn on the LED
+    @returns <code>FINGERPRINT_OK</code> on success
+    @returns anything else for operation failed
+*/
+/**************************************************************************/
+uint8_t Adafruit_Fingerprint::OpenLED(void) {
+  SEND_CMD_PACKET(FINGERPRINT_OPENLED);
+}
+
+// Custom function
+/**************************************************************************/
+/*!
+    @brief   Ask the sensor to turn off the LED
+    @returns <code>FINGERPRINT_OK</code> on success
+    @returns anything else for operation failed
+*/
+/**************************************************************************/
+uint8_t Adafruit_Fingerprint::CloseLED(void) {
+  SEND_CMD_PACKET(FINGERPRINT_CLOSELED);
+}
+
 /**************************************************************************/
 /*!
     @brief   Ask the sensor to take two print feature template and create a

--- a/Adafruit_Fingerprint.cpp
+++ b/Adafruit_Fingerprint.cpp
@@ -178,7 +178,6 @@ uint8_t Adafruit_Fingerprint::image2Tz(uint8_t slot) {
   SEND_CMD_PACKET(FINGERPRINT_IMAGE2TZ, slot);
 }
 
-// Custom function
 /**************************************************************************/
 /*!
     @brief   Ask the sensor to turn on the LED
@@ -190,7 +189,6 @@ uint8_t Adafruit_Fingerprint::OpenLED(void) {
   SEND_CMD_PACKET(FINGERPRINT_OPENLED);
 }
 
-// Custom function
 /**************************************************************************/
 /*!
     @brief   Ask the sensor to turn off the LED

--- a/Adafruit_Fingerprint.cpp
+++ b/Adafruit_Fingerprint.cpp
@@ -184,7 +184,6 @@ uint8_t Adafruit_Fingerprint::image2Tz(uint8_t slot) {
     @returns <code>FINGERPRINT_OK</code> on success
     @returns anything else for operation failed
 */
-/**************************************************************************/
 uint8_t Adafruit_Fingerprint::OpenLED(void) {
   SEND_CMD_PACKET(FINGERPRINT_OPENLED);
 }
@@ -195,7 +194,6 @@ uint8_t Adafruit_Fingerprint::OpenLED(void) {
     @returns <code>FINGERPRINT_OK</code> on success
     @returns anything else for operation failed
 */
-/**************************************************************************/
 uint8_t Adafruit_Fingerprint::CloseLED(void) {
   SEND_CMD_PACKET(FINGERPRINT_CLOSELED);
 }

--- a/Adafruit_Fingerprint.h
+++ b/Adafruit_Fingerprint.h
@@ -78,8 +78,8 @@
 
 #define DEFAULTTIMEOUT 1000 //!< UART reading timeout in milliseconds
 
-#define FINGERPRINT_OPENLED 0x50
-#define FINGERPRINT_CLOSELED 0x51
+#define FINGERPRINT_OPENLED 0x50 //!< Turn on the onboard LED
+#define FINGERPRINT_CLOSELED 0x51 //!< Turn off the onboard LED
 
 ///! Helper class to craft UART packets
 struct Adafruit_Fingerprint_Packet {

--- a/Adafruit_Fingerprint.h
+++ b/Adafruit_Fingerprint.h
@@ -127,9 +127,9 @@ public:
   boolean verifyPassword(void);
   uint8_t getImage(void);
   uint8_t image2Tz(uint8_t slot = 1);
-  uint8_t createModel(void);
   uint8_t OpenLED(void);
   uint8_t CloseLED(void);
+  uint8_t createModel(void);
 
   uint8_t emptyDatabase(void);
   uint8_t storeModel(uint16_t id);

--- a/Adafruit_Fingerprint.h
+++ b/Adafruit_Fingerprint.h
@@ -78,6 +78,9 @@
 
 #define DEFAULTTIMEOUT 1000 //!< UART reading timeout in milliseconds
 
+#define FINGERPRINT_OPENLED 0x50
+#define FINGERPRINT_CLOSELED 0x51
+
 ///! Helper class to craft UART packets
 struct Adafruit_Fingerprint_Packet {
 
@@ -125,6 +128,8 @@ public:
   uint8_t getImage(void);
   uint8_t image2Tz(uint8_t slot = 1);
   uint8_t createModel(void);
+  uint8_t OpenLED(void);
+  uint8_t CloseLED(void);
 
   uint8_t emptyDatabase(void);
   uint8_t storeModel(uint16_t id);


### PR DESCRIPTION
Basically the same PR that can be found here (https://github.com/adafruit/Adafruit-Fingerprint-Sensor-Library/pull/45) but without the merge conflicts so can hopefully be merged as that PR seems to have been stale for quite some time now. 

Thanks to the original author for the work and the description. I've been using the changes myself for a while now but it would be easier to have them integrated into the library rather than users having to edit the files themselves! 

**From original PR:**

Adding LED control functions to the library.
The functions are called "ledOn" and "ledOff"only work on newer version of the sensor, the one with the green LED. This version doesn't have automatic LED control, and several users were having issues because the LED stayed on all the time.

I added them as stand alone functions (and not automatically called when requesting a fingerprint read) because if the user has an older version with embedded LED control, then the commands x50 and x51 won't have a meaning for the CPU.