### PR TITLE
Support a stream for serial

### DIFF
--- a/Adafruit_Fingerprint.cpp
+++ b/Adafruit_Fingerprint.cpp
@@ -102,8 +102,7 @@ Adafruit_Fingerprint::Adafruit_Fingerprint(HardwareSerial *hs,
 */
 /**************************************************************************/
 
-Adafruit_Fingerprint::Adafruit_Fingerprint(Stream *serial,
-                                           uint32_t password) {
+Adafruit_Fingerprint::Adafruit_Fingerprint(Stream *serial, uint32_t password) {
 
   thePassword = password;
   theAddress = 0xFFFFFFFF;

--- a/Adafruit_Fingerprint.cpp
+++ b/Adafruit_Fingerprint.cpp
@@ -95,6 +95,28 @@ Adafruit_Fingerprint::Adafruit_Fingerprint(HardwareSerial *hs,
 
 /**************************************************************************/
 /*!
+    @brief  Instantiates sensor with a stream for Serial
+    @param  serial Pointer to a Stream object
+    @param  password 32-bit integer password (default is 0)
+
+*/
+/**************************************************************************/
+
+Adafruit_Fingerprint::Adafruit_Fingerprint(Stream *serial,
+                                           uint32_t password) {
+
+  thePassword = password;
+  theAddress = 0xFFFFFFFF;
+
+  hwSerial = NULL;
+#if defined(__AVR__) || defined(ESP8266) || defined(FREEDOM_E300_HIFIVE1)
+  swSerial = NULL;
+#endif
+  mySerial = serial;
+}
+
+/**************************************************************************/
+/*!
     @brief  Initializes serial interface and baud rate
     @param  baudrate Sensor's UART baud rate (usually 57600, 9600 or 115200)
 */

--- a/Adafruit_Fingerprint.h
+++ b/Adafruit_Fingerprint.h
@@ -132,6 +132,7 @@ public:
   Adafruit_Fingerprint(SoftwareSerial *ss, uint32_t password = 0x0);
 #endif
   Adafruit_Fingerprint(HardwareSerial *hs, uint32_t password = 0x0);
+  Adafruit_Fingerprint(Stream *serial, uint32_t password = 0x0);
 
   void begin(uint32_t baud);
 


### PR DESCRIPTION
- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

Allow a stream to be used for serial communication with the fingerprint reader. This is useful for platforms that encapsulate serial access through streams (e.g. ESPHome)

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

This doesn't affect existing functionality, and both hardware and software serial constructors are still available.

