### PR TITLE
Differentiate between wrong password and communication error

### DIFF
--- a/Adafruit_Fingerprint.cpp
+++ b/Adafruit_Fingerprint.cpp
@@ -142,14 +142,21 @@ boolean Adafruit_Fingerprint::verifyPassword(void) {
   return checkPassword() == FINGERPRINT_OK;
 }
 
+/**************************************************************************/
+/*!
+    @brief  Verifies the sensors' access password (default password is
+   0x0000000). A good way to also check if the sensors is active and responding
+    @returns <code>FINGERPRINT_OK</code> on success
+    @returns <code>FINGERPRINT_PACKETRECIEVEERR</code> on communication error
+    @returns <code>FINGERPRINT_PASSFAIL</code> on wrong password
+*/
+/**************************************************************************/
+
 uint8_t Adafruit_Fingerprint::checkPassword(void) {
   GET_CMD_PACKET(FINGERPRINT_VERIFYPASSWORD, (uint8_t)(thePassword >> 24),
                  (uint8_t)(thePassword >> 16), (uint8_t)(thePassword >> 8),
                  (uint8_t)(thePassword & 0xFF));
-  if (packet.data[0] == FINGERPRINT_OK)
-    return FINGERPRINT_OK;
-  else
-    return FINGERPRINT_PACKETRECIEVEERR;
+  return packet.data[0];
 }
 
 /**************************************************************************/

--- a/Adafruit_Fingerprint.h
+++ b/Adafruit_Fingerprint.h
@@ -37,8 +37,7 @@
 #define FINGERPRINT_UPLOADFAIL 0x0F  //!< Error when uploading image
 #define FINGERPRINT_DELETEFAIL 0x10  //!< Failed to delete the template
 #define FINGERPRINT_DBCLEARFAIL 0x11 //!< Failed to clear finger library
-#define FINGERPRINT_PASSFAIL                                                   \
-  0x13 //!< Find whether the fingerprint passed or failed
+#define FINGERPRINT_PASSFAIL 0x13 //!< Wrong password
 #define FINGERPRINT_INVALIDIMAGE                                               \
   0x15 //!< Failed to generate image because of lac of valid primary image
 #define FINGERPRINT_FLASHERR 0x18   //!< Error when writing flash
@@ -137,6 +136,7 @@ public:
   void begin(uint32_t baud);
 
   boolean verifyPassword(void);
+  uint8_t checkPassword(void);
   uint8_t getParameters(void);
 
   uint8_t getImage(void);
@@ -178,7 +178,6 @@ public:
   uint16_t baud_rate = 57600; ///< The UART baud rate (set by getParameters)
 
 private:
-  uint8_t checkPassword(void);
   uint32_t thePassword;
   uint32_t theAddress;
   uint8_t recvPacket[20];


### PR DESCRIPTION
Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

Allow public access to checkPassword() to return one of `FINGERPRINT_OK`, `FINGERPRINT_PACKETRECIEVEERR`, `FINGERPRINT_PASSFAIL`. Useful to determine if failure is due to wrong password or communication error.

Also fix comment for `FINGERPRINT_PASSFAIL` (0x13) to reflect the actual meaning as described in the datasheet:

![1](https://user-images.githubusercontent.com/20846761/97342061-c605fa00-18c0-11eb-8830-145231c683d9.PNG)

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

Does not affect existing functionality.