### PR TITLE
show_fingerprint_templates fix for writing beyond array bounds

### DIFF
--- a/examples/show_fingerprint_templates/show_fingerprint_templates.ino
+++ b/examples/show_fingerprint_templates/show_fingerprint_templates.ino
@@ -33,7 +33,7 @@ int getFingerprintIDez();
 
 void setup()
 {
-  while(!Serial);
+  while (!Serial);
   Serial.begin(9600);
   Serial.println("Fingerprint template extractor");
 
@@ -78,55 +78,32 @@ uint8_t downloadFingerprintTemplate(uint16_t id)
     case FINGERPRINT_OK:
       Serial.print("Template "); Serial.print(id); Serial.println(" transferring:");
       break;
-   default:
+    default:
       Serial.print("Unknown error "); Serial.println(p);
       return p;
   }
 
-  // one data packet is 267 bytes. in one data packet, 11 bytes are 'usesless' :D
-  uint8_t bytesReceived[534]; // 2 data packets
-  memset(bytesReceived, 0xff, 534);
-
-  uint32_t starttime = millis();
-  int i = 0;
-  while (i < 534 && (millis() - starttime) < 20000) {
-      if (mySerial.available()) {
-          bytesReceived[i++] = mySerial.read();
-      }
-  }
-  Serial.print(i); Serial.println(" bytes read.");
-  Serial.println("Decoding packet...");
-
-  uint8_t fingerTemplate[512]; // the real template
-  memset(fingerTemplate, 0xff, 512);
-
-  // filtering only the data packets
-  int uindx = 9, index = 0;
-  while (index < 534) {
-      while (index < uindx) ++index;
-      uindx += 256;
-      while (index < uindx) {
-          fingerTemplate[index++] = bytesReceived[index];
-      }
-      uindx += 2;
-      while (index < uindx) ++index;
-      uindx = index + 9;
-  }
-  for (int i = 0; i < 512; ++i) {
-      //Serial.print("0x");
-      printHex(fingerTemplate[i], 2);
-      //Serial.print(", ");
-  }
-  Serial.println("\ndone.");
-
-  return p;
-
   /*
-  uint8_t templateBuffer[256];
-  memset(templateBuffer, 0xff, 256);  //zero out template buffer
-  int index=0;
+     The data comes back as a standard packet
+     2 bytes: 0xef01
+     4 bytes: address
+     1 byte: 0x02 (packet ID)
+     2 bytes: N (data length)
+     N bytes: actual data
+     2 bytes:  checksum
+  */
+
+
+  const int buff_size = 267;
+  const int header_size = 9;
+
+  uint8_t templateBuffer[buff_size];
+  memset(templateBuffer, 0xff, buff_size);  //zero out template buffer
+  int index = 0;
+
+  // attempt to read in header
   uint32_t starttime = millis();
-  while ((index < 256) && ((millis() - starttime) < 1000))
+  while ((index < header_size) && ((millis() - starttime) < 1000))
   {
     if (mySerial.available())
     {
@@ -137,32 +114,66 @@ uint8_t downloadFingerprintTemplate(uint16_t id)
 
   Serial.print(index); Serial.println(" bytes read");
 
+  if ( index != header_size ) {
+    Serial.println("bad header");
+    return 1;
+  }
+
+  uint16_t start = templateBuffer[0] << 8 + templateBuffer[1];
+  uint32_t addr = templateBuffer[2] << 24 + templateBuffer[3] << 16 + templateBuffer[4] << 8 + templateBuffer[5];
+  uint8_t p_id = templateBuffer[6];
+  uint16_t count = templateBuffer[7] << 8 + templateBuffer[8];
+
+  Serial.print( "start: 0x"); Serial.println(start, HEX);
+  Serial.print( "addr: 0x"); Serial.println(addr, HEX);
+  Serial.print( "p_id: 0x"); Serial.println(p_id, HEX);
+  Serial.print( "count: 0x"); Serial.println(count, HEX);
+
+  if ( start != 0xef01 ) { Serial.println("Bad start"); return 1; };
+  if ( p_id != 0x02 ) { Serial.println("Bad packet ID"); return 1; };
+  if ( count > 256) { Serial.println("Count too high"); return 1; };
+
+  count += 2;   // read 2 byte checksum at end of data
+  
+  // attempt to read in data
+  starttime = millis();
+  while (count && ((millis() - starttime) < 10000))
+  {
+    if (mySerial.available())
+    {
+      templateBuffer[index] = mySerial.read();
+      index++;
+      count--;
+    }
+  }
+
+  if ( count ) { Serial.println("timeout reading data"); return 1; }
+  
   //dump entire templateBuffer.  This prints out 16 lines of 16 bytes
-  for (int count= 0; count < 16; count++)
+  for (int count = 0; count < 16; count++)
   {
     for (int i = 0; i < 16; i++)
     {
       Serial.print("0x");
-      Serial.print(templateBuffer[count*16+i], HEX);
+      Serial.print(templateBuffer[count * 16 + i+ header_size], HEX);
       Serial.print(", ");
     }
     Serial.println();
-  }*/
+  }
 }
 
 
 
 void printHex(int num, int precision) {
-    char tmp[16];
-    char format[128];
+  char tmp[16];
+  char format[128];
 
-    sprintf(format, "%%.%dX", precision);
+  sprintf(format, "%%.%dX", precision);
 
-    sprintf(tmp, format, num);
-    Serial.print(tmp);
+  sprintf(tmp, format, num);
+  Serial.print(tmp);
 }
 
 void loop()
 {}
-
 

--- a/examples/show_fingerprint_templates/show_fingerprint_templates.ino
+++ b/examples/show_fingerprint_templates/show_fingerprint_templates.ino
@@ -105,7 +105,7 @@ uint8_t downloadFingerprintTemplate(uint16_t id)
   memcpy(fingerTemplate + index, bytesReceived + uindx, 256);   // first 256 bytes
   uindx += 256;       // skip data
   uindx += 2;         // skip checksum
-  uindx = index + 9;  // skip next header
+  uindx += 9;         // skip next header
   index += 256;       // advance pointer
   memcpy(fingerTemplate + index, bytesReceived + uindx, 256);   // second 256 bytes
 


### PR DESCRIPTION

- changed show_fingerprint_templates.ino example.  Original code would write beyond the array bounds.  Code simplifies down to 2 memcpy() calls
