### PR TITLE
Fix data buffer overflow wrong length bytes

### DIFF
--- a/Adafruit_Fingerprint.cpp
+++ b/Adafruit_Fingerprint.cpp
@@ -559,8 +559,7 @@ Adafruit_Fingerprint::getStructuredPacket(Adafruit_Fingerprint_Packet *packet,
       break;
     }
     idx++;
-    if ((idx + 9) >= sizeof(packet->data))
-    {
+    if ((idx + 9) >= sizeof(packet->data)) {
       return FINGERPRINT_BADPACKET;
     }
   }

--- a/Adafruit_Fingerprint.cpp
+++ b/Adafruit_Fingerprint.cpp
@@ -559,6 +559,10 @@ Adafruit_Fingerprint::getStructuredPacket(Adafruit_Fingerprint_Packet *packet,
       break;
     }
     idx++;
+    if ((idx + 9) >= sizeof(packet->data))
+    {
+      return FINGERPRINT_BADPACKET;
+    }
   }
   // Shouldn't get here so...
   return FINGERPRINT_BADPACKET;


### PR DESCRIPTION
Sometimes receiving byte 6 or 7 is wrong and packet->length will be very high. There was no check that any more bytes could fit into the packet->data buffer. This could resulted in crashes or strange behavior.

These seemingly random crashes occurred on my Arduino Due with a custom pcb and a r503.

This PR adds a check on the current receiving byte counter and checks that it can fit into the data buffer.
