### PR TITLE
New serial begin method for ESP32 to allow the user to specify the cor…

### DIFF
--- a/Adafruit_Fingerprint.cpp
+++ b/Adafruit_Fingerprint.cpp
@@ -140,7 +140,8 @@ void Adafruit_Fingerprint::begin(uint32_t baudrate) {
     @param  txPin pin
 */
 /**************************************************************************/
-void Adafruit_Fingerprint::begin(uint32_t baudrate, int8_t rxPin, int8_t txPin) {
+void Adafruit_Fingerprint::begin(uint32_t baudrate, int8_t rxPin,
+                                 int8_t txPin) {
   delay(1000); // one second delay to let the sensor 'boot up'
 
   hwSerial->begin(baudrate, SERIAL_8N1, rxPin, txPin);

--- a/Adafruit_Fingerprint.cpp
+++ b/Adafruit_Fingerprint.cpp
@@ -131,6 +131,22 @@ void Adafruit_Fingerprint::begin(uint32_t baudrate) {
 #endif
 }
 
+#if defined(ESP32)
+/**************************************************************************/
+/*!
+    @brief  Initializes serial interface and baud rate
+    @param  baudrate Sensor's UART baud rate (usually 57600, 9600 or 115200)
+	  @param  tx pin
+	  @param  rx pin
+*/
+/**************************************************************************/
+void Adafruit_Fingerprint::begin(uint32_t baudrate, int8_t rxPin, int8_t txPin) {
+  delay(1000); // one second delay to let the sensor 'boot up'
+
+  hwSerial->begin(baudrate, SERIAL_8N1, rxPin, txPin);
+}
+#endif
+
 /**************************************************************************/
 /*!
     @brief  Verifies the sensors' access password (default password is

--- a/Adafruit_Fingerprint.cpp
+++ b/Adafruit_Fingerprint.cpp
@@ -136,8 +136,8 @@ void Adafruit_Fingerprint::begin(uint32_t baudrate) {
 /*!
     @brief  Initializes serial interface and baud rate
     @param  baudrate Sensor's UART baud rate (usually 57600, 9600 or 115200)
-	  @param  tx pin
-	  @param  rx pin
+    @param  rxPin pin
+    @param  txPin pin
 */
 /**************************************************************************/
 void Adafruit_Fingerprint::begin(uint32_t baudrate, int8_t rxPin, int8_t txPin) {

--- a/Adafruit_Fingerprint.h
+++ b/Adafruit_Fingerprint.h
@@ -171,7 +171,7 @@ public:
 #if defined(ESP32)
   void begin(uint32_t baud, int8_t rxPin, int8_t txPin);
 #endif
-  
+
   boolean verifyPassword(void);
   uint8_t getParameters(void);
 

--- a/Adafruit_Fingerprint.h
+++ b/Adafruit_Fingerprint.h
@@ -168,9 +168,9 @@ public:
   Adafruit_Fingerprint(Stream *serial, uint32_t password = 0x0);
 
   void begin(uint32_t baud);
-  #if defined(ESP32)
+#if defined(ESP32)
   void begin(uint32_t baud, int8_t rxPin, int8_t txPin);
-  #endif
+#endif
   
   boolean verifyPassword(void);
   uint8_t getParameters(void);

--- a/Adafruit_Fingerprint.h
+++ b/Adafruit_Fingerprint.h
@@ -168,7 +168,10 @@ public:
   Adafruit_Fingerprint(Stream *serial, uint32_t password = 0x0);
 
   void begin(uint32_t baud);
-
+  #if defined(ESP32)
+  void begin(uint32_t baud, int8_t rxPin, int8_t txPin);
+  #endif
+  
   boolean verifyPassword(void);
   uint8_t getParameters(void);
 


### PR DESCRIPTION
New serial begin method for ESP32, that allows to specify custom RX TX pins. As any pin can be used for this.

![grafik](https://user-images.githubusercontent.com/7994357/180056039-2ba88d0d-d8b2-4535-a858-d272d99db421.png)
