### PR TITLE
Add new colors to use with R503 Fingerprint Module

### DIFF
--- a/Adafruit_Fingerprint.h
+++ b/Adafruit_Fingerprint.h
@@ -87,6 +87,10 @@
 #define FINGERPRINT_LED_RED 0x01         //!< Red LED
 #define FINGERPRINT_LED_BLUE 0x02        //!< Blue LED
 #define FINGERPRINT_LED_PURPLE 0x03      //!< Purple LEDpassword
+#define FINGERPRINT_LED_GREEN 0x04      //!< Green LED
+#define FINGERPRINT_LED_GREEN 0x05      //!< Yellow LED
+#define FINGERPRINT_LED_GREEN 0x06      //!< Cyan LED
+#define FINGERPRINT_LED_GREEN 0x07      //!< White LED
 
 #define FINGERPRINT_REG_ADDR_ERROR 0x1A //!< shows register address error
 #define FINGERPRINT_WRITE_REG 0x0E      //!< Write system register instruction


### PR DESCRIPTION
I've added new colors (green, yellow, cyan and white) to use with the [fingerprint module R503](https://de.aliexpress.com/item/33053783539.html?spm=a2g0o.order_list.0.0.6e545c5fZyVkXe&gatewayAdapt=glo2deu).


You can find the manual [here](https://www.dropbox.com/sh/orprmb3bgb6lqb6/AABJrv83ZyzCKCYFGlcjigi0a/User%20Manual%20for%20Fingerprint%20Module?dl=0&subfolder_nav_tracking=1). At page 27 the AuraLedConfig is described.
I already tested it with the R503 Module and it works very well.