### PR TITLE
Add an end() function to close the serial communication

### DIFF
--- a/Adafruit_Fingerprint.cpp
+++ b/Adafruit_Fingerprint.cpp
@@ -131,6 +131,15 @@ void Adafruit_Fingerprint::begin(uint32_t baudrate) {
 #endif
 }
 
+void Adafruit_Fingerprint::end(void) {
+  if (hwSerial)
+    hwSerial->end();
+#if defined(__AVR__) || defined(ESP8266) || defined(FREEDOM_E300_HIFIVE1)
+  if (swSerial)
+    swSerial->end();
+#endif
+}
+
 /**************************************************************************/
 /*!
     @brief  Verifies the sensors' access password (default password is

--- a/Adafruit_Fingerprint.h
+++ b/Adafruit_Fingerprint.h
@@ -168,6 +168,7 @@ public:
   Adafruit_Fingerprint(Stream *serial, uint32_t password = 0x0);
 
   void begin(uint32_t baud);
+  void end(void);
 
   boolean verifyPassword(void);
   uint8_t getParameters(void);


### PR DESCRIPTION
I modified Adafruit_Fingerprint.cpp and Adafruit_Fingerprint.h to add the end() function. It works like begin() but the baud rate doesn't have to be specified. I needed this modification for a project where the fingerprint sensor can be turned off using a switch to save power.
