### PR TITLE
Added function soft Reset + extended begin function with new parameters (as clone of begin function)

### DIFF
--- a/Adafruit_Fingerprint.cpp
+++ b/Adafruit_Fingerprint.cpp
@@ -120,14 +120,14 @@ Adafruit_Fingerprint::Adafruit_Fingerprint(Stream *serial, uint32_t password) {
     @param  baudrate Sensor's UART baud rate (usually 57600, 9600 or 115200)
 */
 /**************************************************************************/
-void Adafruit_Fingerprint::begin(uint32_t baudrate) {
+void Adafruit_Fingerprint::begin(uint32_t baudrate, uint32_t rx, uint32_t tx) {
   delay(1000); // one second delay to let the sensor 'boot up'
 
   if (hwSerial)
-    hwSerial->begin(baudrate);
+    hwSerial->begin(baudrate,SERIAL_8N1,rx,tx);
 #if defined(__AVR__) || defined(ESP8266) || defined(FREEDOM_E300_HIFIVE1)
   if (swSerial)
-    swSerial->begin(baudrate);
+    swSerial->begin(baudrate,SERIAL_8N1,rx,tx);
 #endif
 }
 
@@ -415,6 +415,16 @@ uint8_t Adafruit_Fingerprint::setPassword(uint32_t password) {
   SEND_CMD_PACKET(FINGERPRINT_SETPASSWORD, (uint8_t)(password >> 24),
                   (uint8_t)(password >> 16), (uint8_t)(password >> 8),
                   (uint8_t)(password & 0xFF));
+}
+
+/**************************************************************************/
+/*!
+    @brief   Send soft reset instruction to the module
+    @returns <code>FINGERPRINT_OK</code> on success
+    @returns Other: device is abnormal
+*/
+uint8_t Adafruit_Fingerprint::softReset(void) {
+  SEND_CMD_PACKET(FINGERPRINT_SOFT_RESET);
 }
 
 /**************************************************************************/

--- a/Adafruit_Fingerprint.cpp
+++ b/Adafruit_Fingerprint.cpp
@@ -120,6 +120,25 @@ Adafruit_Fingerprint::Adafruit_Fingerprint(Stream *serial, uint32_t password) {
     @param  baudrate Sensor's UART baud rate (usually 57600, 9600 or 115200)
 */
 /**************************************************************************/
+void Adafruit_Fingerprint::begin(uint32_t baudrate) {
+  delay(1000); // one second delay to let the sensor 'boot up'
+
+  if (hwSerial)
+    hwSerial->begin(baudrate);
+#if defined(__AVR__) || defined(ESP8266) || defined(FREEDOM_E300_HIFIVE1)
+  if (swSerial)
+    swSerial->begin(baudrate);
+#endif
+}
+
+/**************************************************************************/
+/*!
+    @brief  Initializes serial interface and baud rate
+    @param  baudrate Sensor's UART baud rate (usually 57600, 9600 or 115200)
+    @param  rx pin connected to the Sensor to receive data
+    @param  tx pin connected to the Sensor to transmit data
+*/
+/**************************************************************************/
 void Adafruit_Fingerprint::begin(uint32_t baudrate, uint32_t rx, uint32_t tx) {
   delay(1000); // one second delay to let the sensor 'boot up'
 

--- a/Adafruit_Fingerprint.h
+++ b/Adafruit_Fingerprint.h
@@ -74,6 +74,7 @@
   0x1B //!< Asks the sensor to search for a matching fingerprint template to the
        //!< last model generated
 #define FINGERPRINT_TEMPLATECOUNT 0x1D //!< Read finger template numbers
+#define FINGERPRINT_SOFT_RESET 0x3D //!< Soft Reset
 #define FINGERPRINT_AURALEDCONFIG 0x35 //!< Aura LED control
 #define FINGERPRINT_LEDON 0x50         //!< Turn on the onboard LED
 #define FINGERPRINT_LEDOFF 0x51        //!< Turn off the onboard LED
@@ -167,7 +168,7 @@ public:
   Adafruit_Fingerprint(HardwareSerial *hs, uint32_t password = 0x0);
   Adafruit_Fingerprint(Stream *serial, uint32_t password = 0x0);
 
-  void begin(uint32_t baud);
+  void begin(uint32_t baud, uint32_t rx, uint32_t tx);
 
   boolean verifyPassword(void);
   uint8_t getParameters(void);
@@ -185,6 +186,7 @@ public:
   uint8_t fingerSearch(uint8_t slot = 1);
   uint8_t getTemplateCount(void);
   uint8_t setPassword(uint32_t password);
+  uint8_t softReset(void);
   uint8_t LEDcontrol(bool on);
   uint8_t LEDcontrol(uint8_t control, uint8_t speed, uint8_t coloridx,
                      uint8_t count = 0);

--- a/Adafruit_Fingerprint.h
+++ b/Adafruit_Fingerprint.h
@@ -168,6 +168,7 @@ public:
   Adafruit_Fingerprint(HardwareSerial *hs, uint32_t password = 0x0);
   Adafruit_Fingerprint(Stream *serial, uint32_t password = 0x0);
 
+  void begin(uint32_t baud);
   void begin(uint32_t baud, uint32_t rx, uint32_t tx);
 
   boolean verifyPassword(void);


### PR DESCRIPTION
Hello, the following commit does these 2 things:

1) Added support for softReset, where the sensor will simply soft-reset itself (like described in the manual. Tested on R503, working). I did this because my R503 sensor (one of three) is stopping to work after a couple of months. A power cycle solved the issue. The new function resets the sensor as it would be with a power cycle.
2) Added new function begin which is a clone of your begin function but extends it with 2 parameters: rx, tx. These 2 integers are the ports, the sensor is attached to.

There is no breaking change.
There is no limitation in this change.

Actually working in production, tests were made.
